### PR TITLE
Remove stray waitUntil from service worker template

### DIFF
--- a/index.html
+++ b/index.html
@@ -1758,14 +1758,13 @@ if (!data || !Array.isArray(data.items)) throw new Error('Ungültiges Format'); 
     const DB_NAME = 'returnguard_data';
     const DB_VER = 5;
     const ICON = ${JSON.stringify(iconDataUrl)};
-    self.addEventListener('install', (e) => { 
+    self.addEventListener('install', (e) => {
       e.waitUntil((async () => {
         const cache = await caches.open(CACHE);
         try{ await cache.addAll(PRECACHE_URLS); }catch(_){}
         await self.skipWaiting();
       })());
     });
-e.waitUntil(caches.open(CACHE)); });
     self.addEventListener('activate', (e) => { e.waitUntil((async () => {
       const keys = await caches.keys();
       await Promise.all(keys.filter(k => k.startsWith('returnguard-cache-') && k !== CACHE).map(k => caches.delete(k)));


### PR DESCRIPTION
## Summary
- remove the orphaned `e.waitUntil(caches.open(CACHE));` line from the generated service worker install listener
- confirm the generated service worker source still builds and parses cleanly

## Testing
- node <<'NODE'
const fs = require('fs');
const html = fs.readFileSync('ReturnGuard-v2/index.html', 'utf8');
const match = html.match(/function buildSWCode\(iconDataUrl\)\{[\s\S]*?\n  \}/);
if (!match) throw new Error('buildSWCode definition not found');
const fnSource = match[0];
const buildSWCode = new Function(fnSource + '\\nreturn buildSWCode;')();
const swSource = buildSWCode('data:image/png;base64,test');
new Function(swSource);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cebe5bf7ac8332b1ab0cb06bb19a75