### PR TITLE
Remove export buttons from list toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -678,11 +678,6 @@ input,select,textarea{ font-size:16px; border-radius:12px; border:1px solid var(
 <option value="date_desc">Kaufdatum ↓</option>
 <option value="name">Name A→Z</option>
 </select>
-<button aria-label="Export JSON" class="ghost" id="btn_export" type="button">Export JSON</button>
-<button aria-label="Import JSON" class="ghost" id="btn_import" type="button">Import JSON</button>
-<button aria-label="CSV Export" class="ghost" id="btn_csv" type="button">CSV</button>
-<button class="ghost" id="btn_ics7" title="ICS mit Rückgaben der nächsten 7 Tage" type="button">ICS 7T</button>
-<button class="ghost" id="btn_ics14" title="ICS mit Rückgaben der nächsten 14 Tage" type="button">ICS 14T</button>
 </div>
 <div id="list"></div>
 <div class="empty hidden" id="empty">Noch keine Einträge. Füge oben einen Kauf hinzu.</div>


### PR DESCRIPTION
## Summary
- remove the export buttons from the list toolbar so it only shows search, filter, and sort controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ceeeed14388332bc75ce574b5a75f7